### PR TITLE
検索画面で利用する予定のRepositoryItem表示部品を追加

### DIFF
--- a/lib/Widgets/repository_item_info.dart
+++ b/lib/Widgets/repository_item_info.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_codecheck/Widgets/repository_item_info_parts.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+class RepositoryItemInfo extends StatelessWidget {
+  const RepositoryItemInfo({
+    super.key,
+    required this.name,
+    required this.description,
+    required this.language,
+    required this.stargazersCount,
+    required this.watchersCount,
+    required this.forksCount,
+    required this.onTap,
+  });
+
+  final String name;
+  final String description;
+  final String language;
+  final int stargazersCount;
+  final int watchersCount;
+  final int forksCount;
+  final Function onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(name,
+                        style: const TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 16,
+                        )),
+                    Text(description),
+                    const SizedBox(
+                      height: 4,
+                    ),
+                    Row(
+                      children: [
+                        const Text('Langage:'),
+                        Text(language),
+                      ],
+                    ),
+                    const SizedBox(
+                      height: 8,
+                    ),
+                    Row(
+                      children: [
+                        RepositoryItemInfoParts(
+                          iconData: Icons.star_border,
+                          text: stargazersCount.toString(),
+                        ),
+                        const SizedBox(
+                          width: 16,
+                        ),
+                        RepositoryItemInfoParts(
+                          iconData: Icons.visibility,
+                          text: watchersCount.toString(),
+                        ),
+                        const SizedBox(
+                          width: 16,
+                        ),
+                        RepositoryItemInfoParts(
+                          iconData: FontAwesomeIcons.codeFork,
+                          text: forksCount.toString(),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(
+                height: 16,
+                width: 16,
+                child: Icon(Icons.navigate_next),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          const Divider(),
+        ],
+      ),
+      onTap: () => onTap,
+    );
+  }
+}

--- a/lib/Widgets/repository_item_info_parts.dart
+++ b/lib/Widgets/repository_item_info_parts.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class RepositoryItemInfoParts extends StatelessWidget {
+  const RepositoryItemInfoParts(
+      {super.key, required this.iconData, required this.text});
+
+  final IconData iconData;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Icon(iconData),
+        const SizedBox(
+          width: 4,
+        ),
+        Text(text),
+      ],
+    );
+  }
+}

--- a/test/Widgets/repository_item_info_test.dart
+++ b/test/Widgets/repository_item_info_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_codecheck/Widgets/repository_item_info.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('RepositoryItemInfoの表示確認', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: RepositoryItemInfo(
+        name: 'name',
+        description: 'description',
+        forksCount: 1,
+        language: 'language',
+        onTap: () {},
+        stargazersCount: 2,
+        watchersCount: 3,
+      ),
+    ));
+
+    final nameFinder = find.text('name');
+    final descriptionFinder = find.text('description');
+    final forksCountFinder = find.text('1');
+    final languageFinder = find.text('language');
+    final stargazersCountFinder = find.text('2');
+    final watchersCountFinder = find.text('3');
+
+    expect(nameFinder, findsOneWidget);
+    expect(descriptionFinder, findsOneWidget);
+    expect(forksCountFinder, findsOneWidget);
+    expect(languageFinder, findsOneWidget);
+    expect(stargazersCountFinder, findsOneWidget);
+    expect(watchersCountFinder, findsOneWidget);
+    expect(nameFinder, findsOneWidget);
+    await tester.tap(nameFinder);
+    expect(nameFinder, findsOneWidget); //Tapしても何も表示が変わらないこと
+  });
+}


### PR DESCRIPTION
## 変更の概要
* 検索画面のRepositoryリスト表示部品を作成しました。
* #4で作成した画面を本部品に差し替え予定です。

## 変更内容
* RepositoryItemInfoのStatelessWidgetを追加。
* RepositoryItemInfoPartsのStatelessWidgetを追加。
* 追加したWidgetのWidgetTestを追加。