### PR TITLE
Repositoryクラスのメンバ型をnull許容させないように変更

### DIFF
--- a/lib/Entities/repository.dart
+++ b/lib/Entities/repository.dart
@@ -10,8 +10,8 @@ part 'repository.g.dart';
 @freezed
 class Repository with _$Repository {
   const factory Repository({
-    required int? total_count,
-    required List<RepositoryItem>? items,
+    @Default(0) required int total_count,
+    @Default([]) required List<RepositoryItem> items,
   }) = _Repository;
 
   factory Repository.fromJson(Map<String, Object?> json) =>

--- a/lib/Entities/repository.freezed.dart
+++ b/lib/Entities/repository.freezed.dart
@@ -20,8 +20,8 @@ Repository _$RepositoryFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$Repository {
-  int? get total_count => throw _privateConstructorUsedError;
-  List<RepositoryItem>? get items => throw _privateConstructorUsedError;
+  int get total_count => throw _privateConstructorUsedError;
+  List<RepositoryItem> get items => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -35,7 +35,7 @@ abstract class $RepositoryCopyWith<$Res> {
           Repository value, $Res Function(Repository) then) =
       _$RepositoryCopyWithImpl<$Res, Repository>;
   @useResult
-  $Res call({int? total_count, List<RepositoryItem>? items});
+  $Res call({int total_count, List<RepositoryItem> items});
 }
 
 /// @nodoc
@@ -51,18 +51,18 @@ class _$RepositoryCopyWithImpl<$Res, $Val extends Repository>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? total_count = freezed,
-    Object? items = freezed,
+    Object? total_count = null,
+    Object? items = null,
   }) {
     return _then(_value.copyWith(
-      total_count: freezed == total_count
+      total_count: null == total_count
           ? _value.total_count
           : total_count // ignore: cast_nullable_to_non_nullable
-              as int?,
-      items: freezed == items
+              as int,
+      items: null == items
           ? _value.items
           : items // ignore: cast_nullable_to_non_nullable
-              as List<RepositoryItem>?,
+              as List<RepositoryItem>,
     ) as $Val);
   }
 }
@@ -75,7 +75,7 @@ abstract class _$$_RepositoryCopyWith<$Res>
       __$$_RepositoryCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({int? total_count, List<RepositoryItem>? items});
+  $Res call({int total_count, List<RepositoryItem> items});
 }
 
 /// @nodoc
@@ -89,18 +89,18 @@ class __$$_RepositoryCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? total_count = freezed,
-    Object? items = freezed,
+    Object? total_count = null,
+    Object? items = null,
   }) {
     return _then(_$_Repository(
-      total_count: freezed == total_count
+      total_count: null == total_count
           ? _value.total_count
           : total_count // ignore: cast_nullable_to_non_nullable
-              as int?,
-      items: freezed == items
+              as int,
+      items: null == items
           ? _value._items
           : items // ignore: cast_nullable_to_non_nullable
-              as List<RepositoryItem>?,
+              as List<RepositoryItem>,
     ));
   }
 }
@@ -109,22 +109,23 @@ class __$$_RepositoryCopyWithImpl<$Res>
 @JsonSerializable()
 class _$_Repository with DiagnosticableTreeMixin implements _Repository {
   const _$_Repository(
-      {required this.total_count, required final List<RepositoryItem>? items})
+      {required this.total_count = 0,
+      required final List<RepositoryItem> items = const []})
       : _items = items;
 
   factory _$_Repository.fromJson(Map<String, dynamic> json) =>
       _$$_RepositoryFromJson(json);
 
   @override
-  final int? total_count;
-  final List<RepositoryItem>? _items;
+  @JsonKey()
+  final int total_count;
+  final List<RepositoryItem> _items;
   @override
-  List<RepositoryItem>? get items {
-    final value = _items;
-    if (value == null) return null;
+  @JsonKey()
+  List<RepositoryItem> get items {
     if (_items is EqualUnmodifiableListView) return _items;
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
+    return EqualUnmodifiableListView(_items);
   }
 
   @override
@@ -172,16 +173,16 @@ class _$_Repository with DiagnosticableTreeMixin implements _Repository {
 
 abstract class _Repository implements Repository {
   const factory _Repository(
-      {required final int? total_count,
-      required final List<RepositoryItem>? items}) = _$_Repository;
+      {required final int total_count,
+      required final List<RepositoryItem> items}) = _$_Repository;
 
   factory _Repository.fromJson(Map<String, dynamic> json) =
       _$_Repository.fromJson;
 
   @override
-  int? get total_count;
+  int get total_count;
   @override
-  List<RepositoryItem>? get items;
+  List<RepositoryItem> get items;
   @override
   @JsonKey(ignore: true)
   _$$_RepositoryCopyWith<_$_Repository> get copyWith =>

--- a/lib/Entities/repository.g.dart
+++ b/lib/Entities/repository.g.dart
@@ -8,10 +8,11 @@ part of 'repository.dart';
 
 _$_Repository _$$_RepositoryFromJson(Map<String, dynamic> json) =>
     _$_Repository(
-      total_count: json['total_count'] as int?,
+      total_count: json['total_count'] as int? ?? 0,
       items: (json['items'] as List<dynamic>?)
-          ?.map((e) => RepositoryItem.fromJson(e as Map<String, dynamic>))
-          .toList(),
+              ?.map((e) => RepositoryItem.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
     );
 
 Map<String, dynamic> _$$_RepositoryToJson(_$_Repository instance) =>

--- a/test/Entities/repository_test.dart
+++ b/test/Entities/repository_test.dart
@@ -13,18 +13,18 @@ void main() {
 
     expect(repository.total_count, 40);
     expect(repository.items, isNotEmpty);
-    expect(repository.items?[0].id, 3081286);
-    expect(repository.items?[0].name, "Tetris");
-    expect(repository.items?[0].owner?.login, "dtrupenn");
-    expect(repository.items?[0].owner?.avatar_url,
+    expect(repository.items[0].id, 3081286);
+    expect(repository.items[0].name, "Tetris");
+    expect(repository.items[0].owner?.login, "dtrupenn");
+    expect(repository.items[0].owner?.avatar_url,
         "https://secure.gravatar.com/avatar/e7956084e75f239de85d3a31bc172ace?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png");
-    expect(repository.items?[0].html_url, "https://github.com/dtrupenn/Tetris");
-    expect(repository.items?[0].description,
+    expect(repository.items[0].html_url, "https://github.com/dtrupenn/Tetris");
+    expect(repository.items[0].description,
         "A C implementation of Tetris using Pennsim through LC4");
-    expect(repository.items?[0].stargazers_count, 1);
-    expect(repository.items?[0].watchers_count, 1);
-    expect(repository.items?[0].language, "Assembly");
-    expect(repository.items?[0].forks_count, 0);
-    expect(repository.items?[0].open_issues_count, 0);
+    expect(repository.items[0].stargazers_count, 1);
+    expect(repository.items[0].watchers_count, 1);
+    expect(repository.items[0].language, "Assembly");
+    expect(repository.items[0].forks_count, 0);
+    expect(repository.items[0].open_issues_count, 0);
   });
 }


### PR DESCRIPTION
## 変更の概要
* Repositoryクラス（Entity）のメンバ変数にてnull許容させないようにしました。
これにより、画面表示処理時に安全に表示させるようにします。
* #4で作成した画面を本部品に差し替え予定です。

## 変更内容
* Repositoryのメンバ変数の型とデフォルト値を変更。
* freezedにて関連するクラスを自動生成
* 型変更に伴い、UnitTest内容を変更。テスト実施して問題なし。