### PR TITLE
#7 repositoryクラスのdefault値の削除

### DIFF
--- a/lib/Entities/repository.dart
+++ b/lib/Entities/repository.dart
@@ -10,8 +10,8 @@ part 'repository.g.dart';
 @freezed
 class Repository with _$Repository {
   const factory Repository({
-    @Default(0) required int total_count,
-    @Default([]) required List<RepositoryItem> items,
+    required int total_count,
+    required List<RepositoryItem> items,
   }) = _Repository;
 
   factory Repository.fromJson(Map<String, Object?> json) =>

--- a/lib/Entities/repository.freezed.dart
+++ b/lib/Entities/repository.freezed.dart
@@ -109,19 +109,16 @@ class __$$_RepositoryCopyWithImpl<$Res>
 @JsonSerializable()
 class _$_Repository with DiagnosticableTreeMixin implements _Repository {
   const _$_Repository(
-      {required this.total_count = 0,
-      required final List<RepositoryItem> items = const []})
+      {required this.total_count, required final List<RepositoryItem> items})
       : _items = items;
 
   factory _$_Repository.fromJson(Map<String, dynamic> json) =>
       _$$_RepositoryFromJson(json);
 
   @override
-  @JsonKey()
   final int total_count;
   final List<RepositoryItem> _items;
   @override
-  @JsonKey()
   List<RepositoryItem> get items {
     if (_items is EqualUnmodifiableListView) return _items;
     // ignore: implicit_dynamic_type

--- a/lib/Entities/repository.g.dart
+++ b/lib/Entities/repository.g.dart
@@ -8,11 +8,10 @@ part of 'repository.dart';
 
 _$_Repository _$$_RepositoryFromJson(Map<String, dynamic> json) =>
     _$_Repository(
-      total_count: json['total_count'] as int? ?? 0,
-      items: (json['items'] as List<dynamic>?)
-              ?.map((e) => RepositoryItem.fromJson(e as Map<String, dynamic>))
-              .toList() ??
-          const [],
+      total_count: json['total_count'] as int,
+      items: (json['items'] as List<dynamic>)
+          .map((e) => RepositoryItem.fromJson(e as Map<String, dynamic>))
+          .toList(),
     );
 
 Map<String, dynamic> _$$_RepositoryToJson(_$_Repository instance) =>


### PR DESCRIPTION
## 変更の概要
* repository（Entity）クラスの変数のデフォルト値の設定しないように修正。
* #7 のbugfixとなります。

## 変更内容
* repository（Entity）クラスの変数のデフォルト値の設定しないように修正。
* freezedにて関連するクラスを自動生成
* 型変更に伴い、UnitTest内容を変更。テスト実施して問題なし。