### PR TITLE
SearchPageControllerを<AsyncValue<Repository>>で継承させるように変更

### DIFF
--- a/lib/Controller/search_page_controller.dart
+++ b/lib/Controller/search_page_controller.dart
@@ -3,17 +3,25 @@ import 'package:flutter_codecheck/Repository/repo_repository.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final searchPageControllerProvider =
-    StateNotifierProvider<SearchPageController, Repository>((ref) {
+    StateNotifierProvider<SearchPageController, AsyncValue<Repository>>((ref) {
   return SearchPageController(ref.read(repoRepositoryProvider));
 });
 
-class SearchPageController extends StateNotifier<Repository> {
-  SearchPageController(this.repoRepository)
-      : super(const Repository(total_count: 0, items: null));
+class SearchPageController extends StateNotifier<AsyncValue<Repository>> {
+  SearchPageController(this.repoRepository) : super(const AsyncLoading()) {
+    init();
+  }
   RepoRepository repoRepository;
 
-  Future<Repository> fetch(String keyword) async {
-    state = await repoRepository.fetchByKeyword(keyword);
-    return state.copyWith();
+  void init() async {
+    state = const AsyncData(Repository(total_count: 0, items: []));
+  }
+
+  Future<void> fetch(String keyword) async {
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(() async {
+      final data = await repoRepository.fetchByKeyword(keyword);
+      return data;
+    });
   }
 }

--- a/test/Controller/search_page_controller_test.dart
+++ b/test/Controller/search_page_controller_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_codecheck/Controller/search_page_controller.dart';
 import 'package:flutter_codecheck/Entities/repository.dart';
+import 'package:flutter_codecheck/Repository/repo_repository.dart';
 import 'package:flutter_codecheck/Repository/repo_repository_impl.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:mockito/annotations.dart';
@@ -9,23 +11,86 @@ import 'search_page_controller_test.mocks.dart';
 
 @GenerateMocks([RepoRepositoryImpl])
 void main() async {
-  group('fetch処理の確認', () {
-    test('正常取得確認', () async {
+  group('SearchPageCounter_初期値', () {
+    test('初期化時の状態が、初期値の想定と一致していること', () async {
       RepoRepositoryImpl repoRepository = MockRepoRepositoryImpl();
-      when(repoRepository.fetchByKeyword('query')).thenAnswer(
-          (_) async => const Repository(total_count: 0, items: null));
-      final searchPageController = SearchPageController(repoRepository);
-      final state = await searchPageController.fetch('query');
-      expect(state, const Repository(total_count: 0, items: null));
+      final container = ProviderContainer(
+        overrides: [
+          repoRepositoryProvider.overrideWith((ref) => repoRepository)
+        ],
+      );
+
+      expect(
+        container.read(searchPageControllerProvider),
+        const AsyncData(Repository(total_count: 0, items: [])),
+      );
+    });
+  });
+
+  group('SearchPageCounter_fetchの確認', () {
+    test('ローディング状態が正しく動作すること', () async {
+      RepoRepositoryImpl repoRepository = MockRepoRepositoryImpl();
+      when(repoRepository.fetchByKeyword('query'))
+          .thenAnswer((_) async => const Repository(total_count: 0, items: []));
+      final container = ProviderContainer(
+        overrides: [
+          repoRepositoryProvider.overrideWith((ref) => repoRepository)
+        ],
+      );
+
+      final store = container.read(searchPageControllerProvider.notifier);
+      store.fetch('query');
+
+      // 実行直後はローディング中の状態であること
+      expect(
+        container.read(searchPageControllerProvider).isLoading,
+        true,
+      );
     });
 
-    test('例外処理の確認', () async {
+    test('データ取得が正しく読み取れ、状態が更新されること', () async {
+      RepoRepositoryImpl repoRepository = MockRepoRepositoryImpl();
+      when(repoRepository.fetchByKeyword('query'))
+          .thenAnswer((_) async => const Repository(total_count: 1, items: []));
+      final container = ProviderContainer(
+        overrides: [
+          repoRepositoryProvider.overrideWith((ref) => repoRepository),
+        ],
+      );
+
+      final store = container.read(searchPageControllerProvider.notifier);
+      await store.fetch('query');
+
+      // ローディング状態が完了していること
+      expect(
+        container.read(searchPageControllerProvider).isLoading,
+        false,
+      );
+      // stateのrepositoryがMockから取得した値と一致していること
+      expect(
+        container.read(searchPageControllerProvider).value,
+        const Repository(total_count: 1, items: []),
+      );
+    });
+
+    test('Exceptionの状態が正しくCatchできていること', () async {
       RepoRepositoryImpl repoRepository = MockRepoRepositoryImpl();
       when(repoRepository.fetchByKeyword('query'))
           .thenThrow(Exception('GitHubリポジトリの取得に失敗しました'));
-      final searchPageController = SearchPageController(repoRepository);
-      expect(() async => await searchPageController.fetch('query'),
-          throwsException);
+      final container = ProviderContainer(
+        overrides: [
+          repoRepositoryProvider.overrideWith((ref) => repoRepository)
+        ],
+      );
+
+      final store = container.read(searchPageControllerProvider.notifier);
+      await store.fetch('query');
+
+      // stateのerror状態が例外処理をキャッチしていること
+      expect(
+        container.read(searchPageControllerProvider).error,
+        isA<Exception>(),
+      );
     });
   });
 }


### PR DESCRIPTION
## 変更の概要
* SearchPageControllerを<AsyncValue<Repository>>で継承させるように変更。
これによりSearchPageでの検索処理にローディングを表示させるなどを容易にさせる。
* 関連するissueはありません。

## 変更内容
* SearchPageControllerをtateNotifier<AsyncValue<Repository>>に継承させて
関連する処理の見直しを行いました。
* SearchPageControllerの大幅変更に伴い、UnitTestを全般的に見直しし、テストを再実行。問題無し。