### PR TITLE
bugfix: #11 onTapの型定義を変更

### DIFF
--- a/lib/Widgets/repository_item_info.dart
+++ b/lib/Widgets/repository_item_info.dart
@@ -20,11 +20,12 @@ class RepositoryItemInfo extends StatelessWidget {
   final int stargazersCount;
   final int watchersCount;
   final int forksCount;
-  final Function onTap;
+  final Function() onTap;
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
+      onTap: onTap,
       child: Column(
         children: [
           Row(
@@ -88,7 +89,6 @@ class RepositoryItemInfo extends StatelessWidget {
           const Divider(),
         ],
       ),
-      onTap: () => onTap,
     );
   }
 }


### PR DESCRIPTION
## 変更の概要
* 検索リスト部品のonTapの型定義を変更。
* 関連するissue #11 

## 変更内容
* RepositoryItemInfoのonTapをfinal Function() onTap;に変更
* 可読性のため、GestureDetectorのonTapの位置を変更。
* RepositoryItemInfoに関わるUnitTestを追加し、実行。問題無し。