### PR TITLE
RepositoryItemInfoのbehavior設定の変更

### DIFF
--- a/lib/Widgets/repository_item_info.dart
+++ b/lib/Widgets/repository_item_info.dart
@@ -26,6 +26,7 @@ class RepositoryItemInfo extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: onTap,
+      behavior: HitTestBehavior.translucent,
       child: Column(
         children: [
           Row(


### PR DESCRIPTION
## 変更の概要
* 検索リスト部品のGestureDetectorのbehavior設定を変更しました。
* 関連するissue #13 

## 変更内容
* RepositoryItemInfoのGestureDetectorのbehaviorに対して、HitTestBehavior.translucentを設定しました。
* RepositoryItemInfoに関わるUnitTestを追加し、実行。問題無し。