### PR TITLE
#19 再検索時のローディングが表示されないことへの対応

### DIFF
--- a/lib/Controller/search_page_notifier.dart
+++ b/lib/Controller/search_page_notifier.dart
@@ -22,10 +22,11 @@ class SearchPageNotifier extends StateNotifier<AsyncValue<SearchPageState>> {
   }
 
   Future<void> fetch(String keyword) async {
-    state = const AsyncLoading<SearchPageState>().copyWithPrevious(state);
+    final previosState = state.copyWithPrevious(state);
+    state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final data = await repoRepository.fetchByKeyword(keyword);
-      return state.value!.copyWith(repository: data);
+      return previosState.value!.copyWith(repository: data);
     });
   }
 }


### PR DESCRIPTION
## 変更の概要
* 前回の値を変数で保持させた上で、stateをLoading状態にさせるように変更。
* 関連するisuueは #19 です。

## 変更内容
* SearchPageNotifierにて、前回の値を変数で保持させた上で、stateをLoading状態にさせるように変更。
* 関連するクラスにてUnitTest及びWidgetTestを行い、問題なし。