### PR TITLE
前回stateのcopywithを使わない方法に修正

### DIFF
--- a/lib/Controller/search_page_notifier.dart
+++ b/lib/Controller/search_page_notifier.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_codecheck/Controller/search_page_state.dart';
 import 'package:flutter_codecheck/Entities/repository.dart';
 import 'package:flutter_codecheck/Repository/repo_repository.dart';
@@ -22,11 +23,10 @@ class SearchPageNotifier extends StateNotifier<AsyncValue<SearchPageState>> {
   }
 
   Future<void> fetch(String keyword) async {
-    final previosState = state.copyWithPrevious(state);
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final data = await repoRepository.fetchByKeyword(keyword);
-      return previosState.value!.copyWith(repository: data);
+      return SearchPageState(repository: data);
     });
   }
 }


### PR DESCRIPTION
## 変更の概要
* 前回stateのcopywithを使わない方法に修正。
* 関連するissue #19 です。

## 変更内容
* 検索画面のNotifierにて、previosStateを使わない方法に変更。
* 関連するクラスにてUnitTest及びWidgetTestを行い、問題なし。